### PR TITLE
Fixed sizing of Python CPU/GPU memcpy

### DIFF
--- a/harmonize/python/array.py
+++ b/harmonize/python/array.py
@@ -471,7 +471,7 @@ host_to_device_array_template = """
 def {name}(dev_ptr,host_obj):
     ptr = (ffi.from_buffer(host_obj))
     vptr = into_voidptr(ptr)
-    host_to_device(dev_ptr,vptr,size*len(host_obj))
+    host_to_device(dev_ptr,vptr,size*host_obj.size)
 """
 
 host_to_device_object_template = """
@@ -527,7 +527,7 @@ device_to_host_array_template = """
 def {name}(host_obj,dev_ptr):
     ptr = (ffi.from_buffer(host_obj))
     vptr = into_voidptr(ptr)
-    device_to_host(vptr,dev_ptr,size*len(host_obj))
+    device_to_host(vptr,dev_ptr,size*host_obj.size)
 """
 
 device_to_host_object_template = """

--- a/harmonize/python/templates.py
+++ b/harmonize/python/templates.py
@@ -343,6 +343,7 @@ void harmonize_free_device_bytes(void* ptr) {{
 memcpy_host_to_device_template="""
 extern "C"
 void harmonize_memcpy_host_to_device(void *dev_ptr, void *host_ptr, size_t byte_count) {{
+//printf("Copying %zu bytes from %p (host) to %p (device).\\n",byte_count,host_ptr,dev_ptr);
 util::host::auto_throw(adapt::GPUrtMemcpy(
     dev_ptr,
     host_ptr,
@@ -356,6 +357,7 @@ util::host::auto_throw(adapt::GPUrtMemcpy(
 memcpy_device_to_host_template="""
 extern "C"
 void harmonize_memcpy_device_to_host(void *host_ptr, void *dev_ptr, size_t byte_count) {{
+//printf("Copying %zu bytes from %p (device) to %p (host).\\n",byte_count,dev_ptr,host_ptr);
 util::host::auto_throw(adapt::GPUrtMemcpy(
     host_ptr,
     dev_ptr,


### PR DESCRIPTION
Originally, the memcpy provided by the Python API calculated the size of arrays by multiplying the byte-wise size of each element by the number of elements in the array.

This doesn't account for arrays with multiple dimensions. To fix this, the `size` attribute is used in place of the `len` function.